### PR TITLE
feat(tools): add Tatami screenshot-stitching tool

### DIFF
--- a/src/components/ThemeInit.astro
+++ b/src/components/ThemeInit.astro
@@ -1,0 +1,27 @@
+---
+// Sets data-theme before first paint to avoid a flash of the wrong theme.
+// Shared by BaseLayout and ToolLayout so the detection logic lives in one place.
+---
+
+<script is:inline>
+  const getTheme = () => {
+    if (
+      typeof localStorage !== "undefined" &&
+      localStorage.getItem("theme")
+    ) {
+      return localStorage.getItem("theme");
+    }
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      return "dark";
+    }
+    return "light";
+  };
+
+  const theme = getTheme();
+  if (theme === "light") {
+    document.documentElement.setAttribute("data-theme", "light");
+  } else {
+    document.documentElement.setAttribute("data-theme", "dark");
+  }
+  window.localStorage.setItem("theme", theme);
+</script>

--- a/src/components/blog/PostItem.astro
+++ b/src/components/blog/PostItem.astro
@@ -14,11 +14,11 @@ const readingTime = getReadingTime(post);
 ---
 
 <article
-  class="reveal group relative flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-all duration-300 hover:shadow-lg hover:shadow-primary/5"
+  class="reveal group relative flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-all duration-300 hover:border-primary/50 hover:bg-muted/50 hover:shadow-md"
 >
   <a href={`/blog/${post.id}`} class="flex flex-1 flex-col gap-3 p-5">
     <div class="flex-1">
-      <p class="text-xl font-semibold text-foreground group-hover:underline">
+      <p class="text-xl font-semibold text-foreground">
         {post.data.title}
       </p>
     </div>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -16,6 +16,7 @@ export const siteConfig = {
   navLinks: [
     { text: "Home", href: "/" },
     { text: "Blog", href: "/blog" },
+    { text: "Tools", href: "/tools" },
     { text: "About", href: "/about" },
     /* { text: "Contact", href: "/contact" }, */
   ],

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -1,0 +1,17 @@
+export interface Tool {
+  slug: string;
+  title: string;
+  description: string;
+  icon: string;
+  href: string;
+}
+
+export const tools: Tool[] = [
+  {
+    slug: "tatami",
+    title: "Tatami",
+    description: "Arrange and stitch screenshots into a single image.",
+    icon: "tabler:layout-grid",
+    href: "/tools/tatami",
+  },
+];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ interface Props {
 
 import Seo from "../components/seo/Seo.astro";
 import Schema from "../components/seo/Schema.astro";
+import ThemeInit from "../components/ThemeInit.astro";
 import Lightbox from "../components/ui/Lightbox.astro";
 import Navbar from "../components/layout/Navbar.astro";
 import Footer from "../components/layout/Footer.astro";
@@ -45,28 +46,7 @@ const finalIgnoreTitleTemplate = metadata?.ignoreTitleTemplate || false;
     />
     <Schema type="WebSite" data={{}} />
     <slot name="head" />
-    <script is:inline>
-      const getTheme = () => {
-        if (
-          typeof localStorage !== "undefined" &&
-          localStorage.getItem("theme")
-        ) {
-          return localStorage.getItem("theme");
-        }
-        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-          return "dark";
-        }
-        return "light";
-      };
-
-      const theme = getTheme();
-      if (theme === "light") {
-        document.documentElement.setAttribute("data-theme", "light");
-      } else {
-        document.documentElement.setAttribute("data-theme", "dark");
-      }
-      window.localStorage.setItem("theme", theme);
-    </script>
+    <ThemeInit />
   </head>
   <body class="bg-background text-foreground antialiased">
     <a

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -44,6 +44,7 @@ const { title, description, brand = title } = Astro.props;
     <style>
       body {
         height: 100vh;
+        height: 100dvh;
         display: flex;
         flex-direction: column;
         overflow: hidden;
@@ -80,6 +81,7 @@ const { title, description, brand = title } = Astro.props;
         padding: 0 14px;
         height: 46px;
         flex-shrink: 0;
+        overflow-x: auto;
         background: var(--card);
         border-bottom: 1px solid var(--border);
       }

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -1,0 +1,121 @@
+---
+// Minimal, chrome-light shell for full-height in-browser tools (see /tools).
+// Unlike BaseLayout, it skips the navbar/footer/background glow so the tool
+// gets the full viewport — just a slim topbar with a way back home.
+interface Props {
+  title: string;
+  description: string;
+  brand?: string;
+}
+
+import Seo from "../components/seo/Seo.astro";
+import ThemeInit from "../components/ThemeInit.astro";
+import { Icon } from "astro-icon/components";
+import { siteConfig } from "../config/site";
+import "../styles/global.css";
+
+const { title, description, brand = title } = Astro.props;
+---
+
+<!doctype html>
+<html lang={siteConfig.lang}>
+  <head>
+    <Seo title={title} description={description} />
+    <ThemeInit />
+  </head>
+  <body class="bg-background text-foreground antialiased">
+    <div class="tool-app">
+      <div class="tool-topbar">
+        <a
+          href="/"
+          aria-label={`Back to ${siteConfig.name}`}
+          class="tool-home-btn"
+        >
+          <Icon name="tabler:home" class="h-4 w-4" />
+        </a>
+        <div class="tool-divider"></div>
+        <div class="tool-brand">{brand}</div>
+        <slot name="topbar" />
+      </div>
+
+      <slot />
+    </div>
+
+    <style>
+      body {
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .tool-app * {
+          transition: none !important;
+          animation: none !important;
+        }
+      }
+
+      .tool-app {
+        --surface-3: color-mix(in srgb, var(--foreground) 8%, var(--muted));
+        --primary-soft: color-mix(in srgb, var(--primary) 10%, transparent);
+        --primary-border: color-mix(in srgb, var(--primary) 20%, transparent);
+        --shadow:
+          0 1px 2px color-mix(in srgb, var(--foreground) 6%, transparent),
+          0 8px 24px color-mix(in srgb, var(--primary) 14%, transparent);
+        --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Consolas, monospace;
+
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        font-size: 13px;
+        line-height: 1.4;
+      }
+
+      .tool-topbar {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        padding: 0 14px;
+        height: 46px;
+        flex-shrink: 0;
+        background: var(--card);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .tool-home-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 999px;
+        color: var(--muted-foreground);
+        flex-shrink: 0;
+        transition:
+          background-color 0.15s ease,
+          color 0.15s ease;
+      }
+      .tool-home-btn:hover {
+        background: var(--muted);
+        color: var(--foreground);
+      }
+
+      .tool-brand {
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        font-size: 13px;
+        color: var(--foreground);
+        white-space: nowrap;
+      }
+
+      .tool-divider {
+        width: 1px;
+        height: 20px;
+        background: var(--border);
+        flex-shrink: 0;
+      }
+    </style>
+  </body>
+</html>

--- a/src/lib/tools/tatami.ts
+++ b/src/lib/tools/tatami.ts
@@ -14,6 +14,7 @@ interface Placement {
   y: number;
   w: number;
   h: number;
+  clip?: { x: number; y: number; w: number; h: number };
 }
 
 export function initTatami() {
@@ -279,8 +280,8 @@ export function initTatami() {
     } else {
       const cols = gridCols;
       const rows = Math.ceil(images.length / cols);
-      const cellW = Math.max(...images.map((e) => e.w));
-      const cellH = Math.max(...images.map((e) => e.h));
+      const cellW = Math.min(...images.map((e) => e.w));
+      const cellH = Math.min(...images.map((e) => e.h));
       images.forEach((entry, i) => {
         let col: number, row: number;
         if (direction === "western") {
@@ -291,7 +292,7 @@ export function initTatami() {
           row = i % rows;
           col = cols - 1 - colFromRight;
         }
-        const scale = Math.min(cellW / entry.w, cellH / entry.h);
+        const scale = Math.max(cellW / entry.w, cellH / entry.h);
         const w = entry.w * scale;
         const h = entry.h * scale;
         const cellX = col * (cellW + gap);
@@ -302,6 +303,7 @@ export function initTatami() {
           y: cellY + (cellH - h) / 2,
           w,
           h,
+          clip: { x: cellX, y: cellY, w: cellW, h: cellH },
         });
       });
       cw = cols * cellW + (cols - 1) * gap;
@@ -312,7 +314,16 @@ export function initTatami() {
     workCanvas.height = Math.max(1, Math.round(ch));
     ctx.clearRect(0, 0, workCanvas.width, workCanvas.height);
     placements.forEach((p) => {
-      ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
+      if (p.clip) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(p.clip.x, p.clip.y, p.clip.w, p.clip.h);
+        ctx.clip();
+        ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
+        ctx.restore();
+      } else {
+        ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
+      }
     });
 
     const dataUrl = workCanvas.toDataURL("image/png");

--- a/src/lib/tools/tatami.ts
+++ b/src/lib/tools/tatami.ts
@@ -1,0 +1,361 @@
+export type ArrangeMode = "row" | "column" | "grid";
+export type GridDirection = "western" | "japanese";
+
+interface ImageEntry {
+  id: number;
+  img: HTMLImageElement;
+  w: number;
+  h: number;
+}
+
+interface Placement {
+  entry: ImageEntry;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export function initTatami() {
+  let images: ImageEntry[] = [];
+  let nextId = 1;
+  let mode: ArrangeMode = "row";
+  let gap = 0;
+  let gridCols = 2;
+  let direction: GridDirection = "western";
+  let dragSrcIndex: number | null = null;
+  let renderScheduled = false;
+
+  const railList = document.getElementById("railList") as HTMLDivElement;
+  const dropZone = document.getElementById("dropZone") as HTMLDivElement;
+  const emptyState = document.getElementById("emptyState") as HTMLDivElement;
+  const resultImg = document.getElementById("resultImg") as HTMLImageElement;
+  const workCanvas = document.getElementById("workCanvas") as HTMLCanvasElement;
+  const ctx = workCanvas.getContext("2d")!;
+  const imgCount = document.getElementById("imgCount") as HTMLElement;
+  const statCount = document.getElementById("statCount") as HTMLElement;
+  const statDims = document.getElementById("statDims") as HTMLElement;
+  const statSize = document.getElementById("statSize") as HTMLElement;
+  const statTime = document.getElementById("statTime") as HTMLElement;
+  const copyBtn = document.getElementById("copyBtn") as HTMLButtonElement;
+  const flashMsg = document.getElementById("flashMsg") as HTMLElement;
+  const gapSlider = document.getElementById("gapSlider") as HTMLInputElement;
+  const gapValue = document.getElementById("gapValue") as HTMLElement;
+  const colsControl = document.getElementById("colsControl") as HTMLElement;
+  const colsVal = document.getElementById("colsVal") as HTMLElement;
+  const colsMinus = document.getElementById("colsMinus") as HTMLButtonElement;
+  const colsPlus = document.getElementById("colsPlus") as HTMLButtonElement;
+  const directionToggle = document.getElementById(
+    "directionToggle",
+  ) as HTMLElement;
+  const segButtons = document.querySelectorAll<HTMLButtonElement>(".seg-btn");
+  const dirButtons = document.querySelectorAll<HTMLButtonElement>(".dir-btn");
+
+  function addImageFromBlob(blob: Blob) {
+    const url = URL.createObjectURL(blob);
+    const el = new Image();
+    el.onload = function () {
+      images.push({
+        id: nextId++,
+        img: el,
+        w: el.naturalWidth,
+        h: el.naturalHeight,
+      });
+      renderRail();
+      scheduleRender();
+    };
+    el.src = url;
+  }
+
+  window.addEventListener("paste", function (e) {
+    const items = (e.clipboardData && e.clipboardData.items) || [];
+    let found = false;
+    for (const item of items) {
+      if (item.type && item.type.startsWith("image/")) {
+        const blob = item.getAsFile();
+        if (blob) {
+          addImageFromBlob(blob);
+          found = true;
+        }
+      }
+    }
+    if (found) e.preventDefault();
+  });
+
+  ["dragenter", "dragover"].forEach((evt) =>
+    dropZone.addEventListener(evt, function (e) {
+      e.preventDefault();
+      dropZone.classList.add("active");
+    }),
+  );
+  ["dragleave", "drop"].forEach((evt) =>
+    dropZone.addEventListener(evt, function (e) {
+      e.preventDefault();
+      dropZone.classList.remove("active");
+    }),
+  );
+  dropZone.addEventListener("drop", function (e) {
+    const files = (e.dataTransfer && e.dataTransfer.files) || [];
+    for (const f of files) {
+      if (f.type.startsWith("image/")) addImageFromBlob(f);
+    }
+  });
+
+  function renderRail() {
+    imgCount.textContent = String(images.length);
+    railList.innerHTML = "";
+    images.forEach((entry, i) => {
+      const row = document.createElement("div");
+      row.className = "thumb";
+      row.draggable = true;
+      row.dataset.index = String(i);
+
+      const imageWrap = document.createElement("div");
+      imageWrap.className = "thumb-image";
+
+      const im = document.createElement("img");
+      im.src = entry.img.src;
+      imageWrap.appendChild(im);
+
+      const rm = document.createElement("button");
+      rm.className = "remove";
+      rm.textContent = "×";
+      rm.setAttribute("aria-label", "Remove image " + (i + 1));
+      rm.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        images.splice(i, 1);
+        renderRail();
+        scheduleRender();
+      });
+      imageWrap.appendChild(rm);
+
+      row.appendChild(imageWrap);
+
+      const meta = document.createElement("div");
+      meta.className = "meta";
+      const idxEl = document.createElement("div");
+      idxEl.className = "idx";
+      idxEl.textContent = "#" + (i + 1);
+      const dims = document.createElement("div");
+      dims.className = "dims";
+      dims.textContent = entry.w + "×" + entry.h;
+      meta.appendChild(idxEl);
+      meta.appendChild(dims);
+      row.appendChild(meta);
+
+      row.addEventListener("dragstart", function () {
+        dragSrcIndex = i;
+        row.classList.add("dragging");
+      });
+      row.addEventListener("dragend", function () {
+        row.classList.remove("dragging");
+      });
+      row.addEventListener("dragover", function (e) {
+        e.preventDefault();
+        row.classList.add("drop-target");
+      });
+      row.addEventListener("dragleave", function () {
+        row.classList.remove("drop-target");
+      });
+      row.addEventListener("drop", function (e) {
+        e.preventDefault();
+        row.classList.remove("drop-target");
+        if (dragSrcIndex === null || dragSrcIndex === i) return;
+        const moved = images.splice(dragSrcIndex, 1)[0];
+        images.splice(i, 0, moved);
+        dragSrcIndex = null;
+        renderRail();
+        scheduleRender();
+      });
+
+      railList.appendChild(row);
+    });
+  }
+
+  /* ---------- Mode / direction / gap controls ---------- */
+  segButtons.forEach((btn) => {
+    btn.addEventListener("click", function () {
+      setMode(btn.dataset.mode as ArrangeMode);
+    });
+  });
+
+  function setMode(m: ArrangeMode) {
+    mode = m;
+    segButtons.forEach((b) => b.classList.toggle("active", b.dataset.mode === m));
+    const isGrid = m === "grid";
+    colsControl.classList.toggle("disabled", !isGrid);
+    directionToggle.classList.toggle("disabled", !isGrid);
+    scheduleRender();
+  }
+
+  dirButtons.forEach((btn) => {
+    btn.addEventListener("click", function () {
+      direction = btn.dataset.dir as GridDirection;
+      dirButtons.forEach((b) =>
+        b.classList.toggle("active", b.dataset.dir === direction),
+      );
+      scheduleRender();
+    });
+  });
+
+  colsMinus.addEventListener("click", function () {
+    gridCols = Math.max(1, gridCols - 1);
+    colsVal.textContent = String(gridCols);
+    scheduleRender();
+  });
+  colsPlus.addEventListener("click", function () {
+    gridCols = Math.min(8, gridCols + 1);
+    colsVal.textContent = String(gridCols);
+    scheduleRender();
+  });
+
+  gapSlider.addEventListener("input", function () {
+    gap = parseInt(gapSlider.value, 10);
+    gapValue.textContent = gap + "px";
+    gapValue.classList.toggle("flush", gap === 0);
+    scheduleRender();
+  });
+
+  /* ---------- Keyboard shortcuts ---------- */
+  window.addEventListener("keydown", function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const tag = (e.target as HTMLElement | null)?.tagName || "";
+    if (tag === "INPUT" || tag === "TEXTAREA") return;
+    if (e.key === "1") setMode("row");
+    else if (e.key === "2") setMode("column");
+    else if (e.key === "3") setMode("grid");
+    else if (e.key.toLowerCase() === "c") copyResult();
+  });
+
+  /* ---------- Compositing ---------- */
+  function scheduleRender() {
+    if (renderScheduled) return;
+    renderScheduled = true;
+    requestAnimationFrame(function () {
+      renderScheduled = false;
+      composite();
+    });
+  }
+
+  function composite() {
+    if (images.length === 0) {
+      emptyState.style.display = "block";
+      resultImg.style.display = "none";
+      copyBtn.disabled = true;
+      statDims.textContent = "— × —";
+      statSize.textContent = "— KB";
+      statTime.textContent = "—";
+      statCount.textContent = "0";
+      return;
+    }
+
+    const t0 = performance.now();
+    let cw = 0,
+      ch = 0;
+    const placements: Placement[] = [];
+
+    if (mode === "row") {
+      const targetH = Math.min(...images.map((e) => e.h));
+      let x = 0;
+      images.forEach((entry) => {
+        const scale = targetH / entry.h;
+        const w = entry.w * scale;
+        placements.push({ entry, x, y: 0, w, h: targetH });
+        x += w + gap;
+      });
+      cw = x - gap;
+      ch = targetH;
+    } else if (mode === "column") {
+      const targetW = Math.min(...images.map((e) => e.w));
+      let y = 0;
+      images.forEach((entry) => {
+        const scale = targetW / entry.w;
+        const h = entry.h * scale;
+        placements.push({ entry, x: 0, y, w: targetW, h });
+        y += h + gap;
+      });
+      cw = targetW;
+      ch = y - gap;
+    } else {
+      const cols = gridCols;
+      const rows = Math.ceil(images.length / cols);
+      const cellW = Math.max(...images.map((e) => e.w));
+      const cellH = Math.max(...images.map((e) => e.h));
+      images.forEach((entry, i) => {
+        let col: number, row: number;
+        if (direction === "western") {
+          row = Math.floor(i / cols);
+          col = i % cols;
+        } else {
+          const colFromRight = Math.floor(i / rows);
+          row = i % rows;
+          col = cols - 1 - colFromRight;
+        }
+        const scale = Math.min(cellW / entry.w, cellH / entry.h);
+        const w = entry.w * scale;
+        const h = entry.h * scale;
+        const cellX = col * (cellW + gap);
+        const cellY = row * (cellH + gap);
+        placements.push({
+          entry,
+          x: cellX + (cellW - w) / 2,
+          y: cellY + (cellH - h) / 2,
+          w,
+          h,
+        });
+      });
+      cw = cols * cellW + (cols - 1) * gap;
+      ch = rows * cellH + (rows - 1) * gap;
+    }
+
+    workCanvas.width = Math.max(1, Math.round(cw));
+    workCanvas.height = Math.max(1, Math.round(ch));
+    ctx.clearRect(0, 0, workCanvas.width, workCanvas.height);
+    placements.forEach((p) => {
+      ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
+    });
+
+    const dataUrl = workCanvas.toDataURL("image/png");
+    resultImg.src = dataUrl;
+    resultImg.style.display = "block";
+    emptyState.style.display = "none";
+    copyBtn.disabled = false;
+
+    const t1 = performance.now();
+    const approxBytes = Math.round(
+      (dataUrl.length - "data:image/png;base64,".length) * 0.75,
+    );
+    statDims.textContent = workCanvas.width + " × " + workCanvas.height;
+    statSize.textContent = (approxBytes / 1024).toFixed(1) + " KB";
+    statTime.textContent = (t1 - t0).toFixed(1);
+    statCount.textContent = String(images.length);
+  }
+
+  /* ---------- Copy ---------- */
+  function flash(text: string, ok: boolean) {
+    flashMsg.textContent = text;
+    flashMsg.className = "flash-msg " + (ok ? "ok" : "err");
+    if (ok)
+      setTimeout(() => {
+        flashMsg.textContent = "";
+      }, 1800);
+  }
+
+  async function copyResult() {
+    if (images.length === 0) return;
+    try {
+      const blob = await new Promise<Blob | null>((resolve) =>
+        workCanvas.toBlob(resolve, "image/png"),
+      );
+      if (!blob) throw new Error("no blob");
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      flash("Copied ✓", true);
+    } catch {
+      flash("Clipboard blocked in preview — right-click the image instead", false);
+    }
+  }
+  copyBtn.addEventListener("click", copyResult);
+
+  renderRail();
+  composite();
+}

--- a/src/lib/tools/tatami.ts
+++ b/src/lib/tools/tatami.ts
@@ -37,7 +37,6 @@ export function initTatami() {
   const statDims = document.getElementById("statDims") as HTMLElement;
   const statSize = document.getElementById("statSize") as HTMLElement;
   const statTime = document.getElementById("statTime") as HTMLElement;
-  const copyBtn = document.getElementById("copyBtn") as HTMLButtonElement;
   const flashMsg = document.getElementById("flashMsg") as HTMLElement;
   const gapSlider = document.getElementById("gapSlider") as HTMLInputElement;
   const gapValue = document.getElementById("gapValue") as HTMLElement;
@@ -241,7 +240,6 @@ export function initTatami() {
     if (images.length === 0) {
       emptyState.style.display = "block";
       resultImg.style.display = "none";
-      copyBtn.disabled = true;
       statDims.textContent = "— × —";
       statSize.textContent = "— KB";
       statTime.textContent = "—";
@@ -319,7 +317,6 @@ export function initTatami() {
     resultImg.src = dataUrl;
     resultImg.style.display = "block";
     emptyState.style.display = "none";
-    copyBtn.disabled = false;
 
     const t1 = performance.now();
     const approxBytes = Math.round(
@@ -354,7 +351,6 @@ export function initTatami() {
       flash("Clipboard blocked in preview — right-click the image instead", false);
     }
   }
-  copyBtn.addEventListener("click", copyResult);
 
   renderRail();
   composite();

--- a/src/lib/tools/tatami.ts
+++ b/src/lib/tools/tatami.ts
@@ -4,6 +4,7 @@ export type GridDirection = "western" | "japanese";
 interface ImageEntry {
   id: number;
   img: HTMLImageElement;
+  url: string;
   w: number;
   h: number;
 }
@@ -57,6 +58,7 @@ export function initTatami() {
       images.push({
         id: nextId++,
         img: el,
+        url,
         w: el.naturalWidth,
         h: el.naturalHeight,
       });
@@ -100,75 +102,109 @@ export function initTatami() {
     }
   });
 
+  interface RailRow {
+    row: HTMLDivElement;
+    idxEl: HTMLDivElement;
+    rm: HTMLButtonElement;
+  }
+
+  const railRows = new Map<number, RailRow>();
+
+  function indexOfId(id: number): number {
+    return images.findIndex((e) => e.id === id);
+  }
+
+  function createRailRow(entry: ImageEntry): RailRow {
+    const row = document.createElement("div");
+    row.className = "thumb";
+    row.draggable = true;
+
+    const imageWrap = document.createElement("div");
+    imageWrap.className = "thumb-image";
+
+    const im = document.createElement("img");
+    im.src = entry.img.src;
+    imageWrap.appendChild(im);
+
+    const rm = document.createElement("button");
+    rm.className = "remove";
+    rm.textContent = "×";
+    rm.addEventListener("click", function (ev) {
+      ev.stopPropagation();
+      const i = indexOfId(entry.id);
+      if (i === -1) return;
+      URL.revokeObjectURL(images[i].url);
+      images.splice(i, 1);
+      renderRail();
+      scheduleRender();
+    });
+    imageWrap.appendChild(rm);
+
+    row.appendChild(imageWrap);
+
+    const meta = document.createElement("div");
+    meta.className = "meta";
+    const idxEl = document.createElement("div");
+    idxEl.className = "idx";
+    const dims = document.createElement("div");
+    dims.className = "dims";
+    dims.textContent = entry.w + "×" + entry.h;
+    meta.appendChild(idxEl);
+    meta.appendChild(dims);
+    row.appendChild(meta);
+
+    row.addEventListener("dragstart", function () {
+      dragSrcIndex = indexOfId(entry.id);
+      row.classList.add("dragging");
+    });
+    row.addEventListener("dragend", function () {
+      row.classList.remove("dragging");
+    });
+    row.addEventListener("dragover", function (e) {
+      e.preventDefault();
+      row.classList.add("drop-target");
+    });
+    row.addEventListener("dragleave", function () {
+      row.classList.remove("drop-target");
+    });
+    row.addEventListener("drop", function (e) {
+      e.preventDefault();
+      row.classList.remove("drop-target");
+      const targetIndex = indexOfId(entry.id);
+      if (dragSrcIndex === null || dragSrcIndex === targetIndex) return;
+      const moved = images.splice(dragSrcIndex, 1)[0];
+      images.splice(targetIndex, 0, moved);
+      dragSrcIndex = null;
+      renderRail();
+      scheduleRender();
+    });
+
+    return { row, idxEl, rm };
+  }
+
   function renderRail() {
     imgCount.textContent = String(images.length);
-    railList.innerHTML = "";
+
+    const seen = new Set<number>();
     images.forEach((entry, i) => {
-      const row = document.createElement("div");
-      row.className = "thumb";
-      row.draggable = true;
-      row.dataset.index = String(i);
-
-      const imageWrap = document.createElement("div");
-      imageWrap.className = "thumb-image";
-
-      const im = document.createElement("img");
-      im.src = entry.img.src;
-      imageWrap.appendChild(im);
-
-      const rm = document.createElement("button");
-      rm.className = "remove";
-      rm.textContent = "×";
-      rm.setAttribute("aria-label", "Remove image " + (i + 1));
-      rm.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        images.splice(i, 1);
-        renderRail();
-        scheduleRender();
-      });
-      imageWrap.appendChild(rm);
-
-      row.appendChild(imageWrap);
-
-      const meta = document.createElement("div");
-      meta.className = "meta";
-      const idxEl = document.createElement("div");
-      idxEl.className = "idx";
-      idxEl.textContent = "#" + (i + 1);
-      const dims = document.createElement("div");
-      dims.className = "dims";
-      dims.textContent = entry.w + "×" + entry.h;
-      meta.appendChild(idxEl);
-      meta.appendChild(dims);
-      row.appendChild(meta);
-
-      row.addEventListener("dragstart", function () {
-        dragSrcIndex = i;
-        row.classList.add("dragging");
-      });
-      row.addEventListener("dragend", function () {
-        row.classList.remove("dragging");
-      });
-      row.addEventListener("dragover", function (e) {
-        e.preventDefault();
-        row.classList.add("drop-target");
-      });
-      row.addEventListener("dragleave", function () {
-        row.classList.remove("drop-target");
-      });
-      row.addEventListener("drop", function (e) {
-        e.preventDefault();
-        row.classList.remove("drop-target");
-        if (dragSrcIndex === null || dragSrcIndex === i) return;
-        const moved = images.splice(dragSrcIndex, 1)[0];
-        images.splice(i, 0, moved);
-        dragSrcIndex = null;
-        renderRail();
-        scheduleRender();
-      });
-
-      railList.appendChild(row);
+      seen.add(entry.id);
+      let entryRow = railRows.get(entry.id);
+      if (!entryRow) {
+        entryRow = createRailRow(entry);
+        railRows.set(entry.id, entryRow);
+      }
+      entryRow.row.dataset.index = String(i);
+      entryRow.idxEl.textContent = "#" + (i + 1);
+      entryRow.rm.setAttribute("aria-label", "Remove image " + (i + 1));
+      railList.appendChild(entryRow.row);
     });
+
+    for (const [id, entryRow] of railRows) {
+      if (!seen.has(id)) {
+        entryRow.row.remove();
+        railRows.delete(id);
+      }
+    }
   }
 
   /* ---------- Mode / direction / gap controls ---------- */
@@ -184,6 +220,9 @@ export function initTatami() {
     const isGrid = m === "grid";
     colsControl.classList.toggle("disabled", !isGrid);
     directionToggle.classList.toggle("disabled", !isGrid);
+    colsMinus.disabled = !isGrid;
+    colsPlus.disabled = !isGrid;
+    dirButtons.forEach((b) => (b.disabled = !isGrid));
     scheduleRender();
   }
 
@@ -340,6 +379,7 @@ export function initTatami() {
 
   async function copyResult() {
     if (images.length === 0) return;
+    composite();
     try {
       const blob = await new Promise<Blob | null>((resolve) =>
         workCanvas.toBlob(resolve, "image/png"),

--- a/src/lib/tools/tatami.ts
+++ b/src/lib/tools/tatami.ts
@@ -14,7 +14,6 @@ interface Placement {
   y: number;
   w: number;
   h: number;
-  clip?: { x: number; y: number; w: number; h: number };
 }
 
 export function initTatami() {
@@ -292,7 +291,7 @@ export function initTatami() {
           row = i % rows;
           col = cols - 1 - colFromRight;
         }
-        const scale = Math.max(cellW / entry.w, cellH / entry.h);
+        const scale = Math.min(cellW / entry.w, cellH / entry.h);
         const w = entry.w * scale;
         const h = entry.h * scale;
         const cellX = col * (cellW + gap);
@@ -303,7 +302,6 @@ export function initTatami() {
           y: cellY + (cellH - h) / 2,
           w,
           h,
-          clip: { x: cellX, y: cellY, w: cellW, h: cellH },
         });
       });
       cw = cols * cellW + (cols - 1) * gap;
@@ -314,16 +312,7 @@ export function initTatami() {
     workCanvas.height = Math.max(1, Math.round(ch));
     ctx.clearRect(0, 0, workCanvas.width, workCanvas.height);
     placements.forEach((p) => {
-      if (p.clip) {
-        ctx.save();
-        ctx.beginPath();
-        ctx.rect(p.clip.x, p.clip.y, p.clip.w, p.clip.h);
-        ctx.clip();
-        ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
-        ctx.restore();
-      } else {
-        ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
-      }
+      ctx.drawImage(p.entry.img, p.x, p.y, p.w, p.h);
     });
 
     const dataUrl = workCanvas.toDataURL("image/png");

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -4,7 +4,8 @@ import { getCollection } from "astro:content";
 import PostItem from "../../components/blog/PostItem.astro";
 import Pagination from "../../components/ui/Pagination.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import Content from "../../components/widgets/Content.astro";
+import WidgetWrapper from "../../components/widgets/WidgetWrapper.astro";
+import Headline from "../../components/ui/Headline.astro";
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
   const blogEntries = await getCollection("blog");
@@ -25,14 +26,17 @@ const metadata = {
 ---
 
 <BaseLayout metadata={metadata}>
-  <section class="relative px-4 sm:px-6 lg:px-8 min-h-[calc(100vh-72px)]">
-    <div class="relative mx-auto max-w-4xl">
-      <Content title="Blog" />
-
-      <div class="flex flex-col gap-4 mb-4">
+  <div class="min-h-[calc(100vh-72px)]">
+    <WidgetWrapper>
+      <Headline
+        title="Blog"
+        subtitle="Musings and write-ups I've put together."
+        classes={{ container: "max-w-2xl mx-auto text-center" }}
+      />
+      <div class="flex flex-col gap-4 mb-4 mt-12">
         {blog.map((post) => <PostItem post={post} />)}
       </div>
       <Pagination page={page} />
-    </div>
-  </section>
+    </WidgetWrapper>
+  </div>
 </BaseLayout>

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -15,13 +15,13 @@ const metadata = {
 
 <BaseLayout {metadata}>
   <div class="min-h-[calc(100vh-72px)]">
-    <WidgetWrapper containerClass="py-16 md:py-24">
+    <WidgetWrapper>
       <Headline
         title="Tools"
-        subtitle="Small in-browser apps I've built for myself — no accounts, no servers, just useful."
+        subtitle="Small in-browser apps I've built for myself."
         classes={{ container: "max-w-2xl mx-auto text-center" }}
       />
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-12">
         {
           tools.map((tool) => (
             <Card
@@ -34,15 +34,9 @@ const metadata = {
               <h3 class="text-xl font-bold text-foreground mb-3">
                 {tool.title}
               </h3>
-              <p class="text-muted-foreground text-sm mb-6">
+              <p class="text-muted-foreground text-sm mb-2">
                 {tool.description}
               </p>
-              <span class="text-primary font-semibold flex items-center gap-2 group-hover:underline">
-                Open
-                <span class="transition-transform group-hover:translate-x-1">
-                  →
-                </span>
-              </span>
             </Card>
           ))
         }

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -1,0 +1,52 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import WidgetWrapper from "../components/widgets/WidgetWrapper.astro";
+import Headline from "../components/ui/Headline.astro";
+import Card from "../components/ui/Card.astro";
+import { Icon } from "astro-icon/components";
+import { tools } from "../config/tools";
+
+const metadata = {
+  title: "Tools",
+  description:
+    "Small in-browser apps and utilities",
+};
+---
+
+<BaseLayout {metadata}>
+  <div class="min-h-[calc(100vh-72px)]">
+    <WidgetWrapper containerClass="py-16 md:py-24">
+      <Headline
+        title="Tools"
+        subtitle="Small in-browser apps I've built for myself — no accounts, no servers, just useful."
+        classes={{ container: "max-w-2xl mx-auto text-center" }}
+      />
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {
+          tools.map((tool) => (
+            <Card
+              href={tool.href}
+              class="group text-left hover:bg-muted/50 hover:shadow-md"
+            >
+              <div class="w-12 h-12 rounded-lg flex items-center justify-center mb-6 bg-primary/10 text-primary">
+                <Icon name={tool.icon} class="w-6 h-6" />
+              </div>
+              <h3 class="text-xl font-bold text-foreground mb-3">
+                {tool.title}
+              </h3>
+              <p class="text-muted-foreground text-sm mb-6">
+                {tool.description}
+              </p>
+              <span class="text-primary font-semibold flex items-center gap-2 group-hover:underline">
+                Open
+                <span class="transition-transform group-hover:translate-x-1">
+                  →
+                </span>
+              </span>
+            </Card>
+          ))
+        }
+      </div>
+    </WidgetWrapper>
+  </div>
+</BaseLayout>

--- a/src/pages/tools/tatami.astro
+++ b/src/pages/tools/tatami.astro
@@ -17,7 +17,7 @@ const metadata = {
     </div>
 
     <div class="cols-control disabled" id="colsControl">
-      <label>cols</label>
+      <label>Columns</label>
       <div class="stepper">
         <button id="colsMinus" aria-label="Fewer columns">−</button>
         <div class="stepper-val" id="colsVal">2</div>
@@ -43,9 +43,9 @@ const metadata = {
     </div>
 
     <div class="topbar-hints">
-      <span><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd> mode</span>
-      <span><kbd>⌘V</kbd> paste</span>
-      <span><kbd>C</kbd> copy</span>
+      <span><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd> Mode</span>
+      <span><kbd>⌘V</kbd> Paste</span>
+      <span><kbd>C</kbd> Copy</span>
     </div>
   </Fragment>
 
@@ -77,7 +77,7 @@ const metadata = {
         <div class="stat-sep"></div>
         <span id="statSize">— KB</span>
         <div class="stat-sep"></div>
-        <span>render <b id="statTime">—</b> ms</span>
+        <span>Render <b id="statTime">—</b> ms</span>
         <span class="flash-msg" id="flashMsg"></span>
         <button class="copy-btn" id="copyBtn" disabled>Copy <kbd>C</kbd></button>
       </div>

--- a/src/pages/tools/tatami.astro
+++ b/src/pages/tools/tatami.astro
@@ -159,6 +159,7 @@ const metadata = {
     .gap-control input[type="range"] {
       width: 90px;
       accent-color: var(--primary);
+      cursor: pointer;
     }
     .gap-value {
       font-family: var(--font-mono);

--- a/src/pages/tools/tatami.astro
+++ b/src/pages/tools/tatami.astro
@@ -79,7 +79,6 @@ const metadata = {
         <div class="stat-sep"></div>
         <span>Render <b id="statTime">—</b> ms</span>
         <span class="flash-msg" id="flashMsg"></span>
-        <button class="copy-btn" id="copyBtn" disabled>Copy <kbd>C</kbd></button>
       </div>
     </div>
   </div>
@@ -316,7 +315,12 @@ const metadata = {
       margin: 6px;
       border: 1px dashed var(--border);
       border-radius: 8px;
-      padding: 18px 10px;
+      padding: 32px 10px;
+      min-height: 96px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
       text-align: center;
       color: var(--muted-foreground);
       font-size: 11.5px;
@@ -409,44 +413,6 @@ const metadata = {
       width: 1px;
       height: 12px;
       background: var(--border);
-    }
-
-    .copy-btn {
-      margin-left: auto;
-      appearance: none;
-      border: none;
-      background: var(--foreground);
-      color: var(--background);
-      font-size: 12px;
-      font-weight: 700;
-      padding: 6px 14px;
-      border-radius: 12px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      box-shadow: var(--shadow);
-      transition:
-        transform 0.15s ease,
-        opacity 0.15s ease;
-    }
-    .copy-btn:hover {
-      opacity: 0.9;
-      transform: scale(1.03);
-    }
-    .copy-btn:disabled {
-      opacity: 0.4;
-      cursor: default;
-      transform: none;
-      box-shadow: none;
-    }
-    .copy-btn kbd {
-      font-family: var(--font-mono);
-      font-size: 10px;
-      border: 1px solid currentColor;
-      border-radius: 2px;
-      padding: 0 3px;
-      opacity: 0.85;
     }
 
     .flash-msg {

--- a/src/pages/tools/tatami.astro
+++ b/src/pages/tools/tatami.astro
@@ -19,17 +19,17 @@ const metadata = {
     <div class="cols-control disabled" id="colsControl">
       <label>Columns</label>
       <div class="stepper">
-        <button id="colsMinus" aria-label="Fewer columns">−</button>
+        <button id="colsMinus" aria-label="Fewer columns" disabled>−</button>
         <div class="stepper-val" id="colsVal">2</div>
-        <button id="colsPlus" aria-label="More columns">+</button>
+        <button id="colsPlus" aria-label="More columns" disabled>+</button>
       </div>
     </div>
 
     <div class="direction-toggle disabled" id="directionToggle">
-      <button class="dir-btn active" data-dir="western">
+      <button class="dir-btn active" data-dir="western" disabled>
         <span class="glyph">→↓</span> Western
       </button>
-      <button class="dir-btn" data-dir="japanese">
+      <button class="dir-btn" data-dir="japanese" disabled>
         <span class="glyph">↓←</span> Japanese
       </button>
     </div>
@@ -142,6 +142,13 @@ const metadata = {
       border-radius: 3px;
       padding: 0 3px;
       line-height: 1.4;
+    }
+
+    .tool-divider {
+      width: 1px;
+      height: 20px;
+      background: var(--border);
+      flex-shrink: 0;
     }
 
     .gap-control {
@@ -273,7 +280,7 @@ const metadata = {
 
     /* ---------- Rail ---------- */
     .rail {
-      width: 240px;
+      width: clamp(160px, 42vw, 240px);
       flex-shrink: 0;
       background: var(--card);
       border-right: 1px solid var(--border);

--- a/src/pages/tools/tatami.astro
+++ b/src/pages/tools/tatami.astro
@@ -1,0 +1,549 @@
+---
+import ToolLayout from "../../layouts/ToolLayout.astro";
+
+const metadata = {
+  title: "Tatami",
+  description:
+    "Arrange and stitch screenshots into a single image, right in your browser.",
+};
+---
+
+<ToolLayout title={metadata.title} description={metadata.description}>
+  <Fragment slot="topbar">
+    <div class="segmented" role="group" aria-label="Arrange mode">
+      <button class="seg-btn active" data-mode="row">Row <kbd>1</kbd></button>
+      <button class="seg-btn" data-mode="column">Column <kbd>2</kbd></button>
+      <button class="seg-btn" data-mode="grid">Grid <kbd>3</kbd></button>
+    </div>
+
+    <div class="cols-control disabled" id="colsControl">
+      <label>cols</label>
+      <div class="stepper">
+        <button id="colsMinus" aria-label="Fewer columns">−</button>
+        <div class="stepper-val" id="colsVal">2</div>
+        <button id="colsPlus" aria-label="More columns">+</button>
+      </div>
+    </div>
+
+    <div class="direction-toggle disabled" id="directionToggle">
+      <button class="dir-btn active" data-dir="western">
+        <span class="glyph">→↓</span> Western
+      </button>
+      <button class="dir-btn" data-dir="japanese">
+        <span class="glyph">↓←</span> Japanese
+      </button>
+    </div>
+
+    <div class="tool-divider"></div>
+
+    <div class="gap-control">
+      <label for="gapSlider">Gap</label>
+      <input type="range" id="gapSlider" min="0" max="40" value="0" />
+      <div class="gap-value flush" id="gapValue">0px</div>
+    </div>
+
+    <div class="topbar-hints">
+      <span><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd> mode</span>
+      <span><kbd>⌘V</kbd> paste</span>
+      <span><kbd>C</kbd> copy</span>
+    </div>
+  </Fragment>
+
+  <div class="workspace">
+    <div class="rail">
+      <div class="rail-header">
+        <span class="rail-title">Images</span>
+        <span class="count" id="imgCount">0</span>
+      </div>
+      <div class="drop-zone" id="dropZone">
+        Drop images here<br />or <kbd>⌘V</kbd> to paste
+      </div>
+      <div class="rail-list" id="railList"></div>
+    </div>
+
+    <div class="preview-pane">
+      <div class="preview-canvas-area" id="previewArea">
+        <div class="empty-state" id="emptyState">
+          <div class="big">⌘V</div>
+          Paste a few screenshots, or drop image files onto the rail to start
+          composing.
+        </div>
+        <img id="resultImg" alt="Composed result" style="display:none;" />
+      </div>
+      <div class="statusbar">
+        <span><b id="statCount">0</b> images</span>
+        <div class="stat-sep"></div>
+        <span id="statDims">— × —</span>
+        <div class="stat-sep"></div>
+        <span id="statSize">— KB</span>
+        <div class="stat-sep"></div>
+        <span>render <b id="statTime">—</b> ms</span>
+        <span class="flash-msg" id="flashMsg"></span>
+        <button class="copy-btn" id="copyBtn" disabled>Copy <kbd>C</kbd></button>
+      </div>
+    </div>
+  </div>
+
+  <canvas id="workCanvas" style="display:none;"></canvas>
+
+  <script>
+    import { initTatami } from "../../lib/tools/tatami";
+    initTatami();
+  </script>
+
+  <style>
+    .workspace {
+      flex: 1;
+      display: flex;
+      min-height: 0;
+    }
+
+    /* ---------- Topbar controls ---------- */
+    .segmented {
+      display: flex;
+      background: var(--muted);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 3px;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+
+    .seg-btn {
+      appearance: none;
+      border: none;
+      background: transparent;
+      color: var(--muted-foreground);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 5px 12px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition:
+        background-color 0.15s ease,
+        color 0.15s ease;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+    }
+    .seg-btn:hover {
+      color: var(--foreground);
+    }
+    .seg-btn.active {
+      background: var(--foreground);
+      color: var(--background);
+      font-weight: 700;
+    }
+    .seg-btn kbd {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      opacity: 0.7;
+      border: 1px solid currentColor;
+      border-radius: 3px;
+      padding: 0 3px;
+      line-height: 1.4;
+    }
+
+    .gap-control {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+    .gap-control label {
+      color: var(--muted-foreground);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+    .gap-control input[type="range"] {
+      width: 90px;
+      accent-color: var(--primary);
+    }
+    .gap-value {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      width: 42px;
+      color: var(--foreground);
+    }
+    .gap-value.flush {
+      color: var(--primary);
+      font-weight: 600;
+    }
+
+    .direction-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+      transition: opacity 0.15s ease;
+    }
+    .direction-toggle.disabled {
+      opacity: 0.35;
+      pointer-events: none;
+    }
+    .dir-btn {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: var(--muted);
+      border: 1px solid var(--border);
+      color: var(--muted-foreground);
+      font-size: 11.5px;
+      padding: 5px 10px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease;
+    }
+    .dir-btn.active {
+      border-color: var(--primary-border);
+      color: var(--primary);
+      background: var(--primary-soft);
+    }
+    .dir-btn .glyph {
+      font-family: var(--font-mono);
+      font-size: 13px;
+    }
+    .dir-btn.active .glyph {
+      color: var(--primary);
+    }
+
+    .cols-control {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+      transition: opacity 0.15s ease;
+    }
+    .cols-control.disabled {
+      opacity: 0.35;
+      pointer-events: none;
+    }
+    .cols-control label {
+      color: var(--muted-foreground);
+      font-size: 12px;
+    }
+    .stepper {
+      display: flex;
+      align-items: center;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .stepper button {
+      appearance: none;
+      border: none;
+      background: var(--muted);
+      color: var(--foreground);
+      width: 22px;
+      height: 24px;
+      cursor: pointer;
+      font-family: var(--font-mono);
+      font-size: 12px;
+    }
+    .stepper button:hover {
+      background: var(--surface-3);
+    }
+    .stepper .stepper-val {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      width: 20px;
+      text-align: center;
+      color: var(--foreground);
+    }
+
+    .topbar-hints {
+      margin-left: auto;
+      display: flex;
+      gap: 12px;
+      color: var(--muted-foreground);
+      font-size: 11px;
+      font-family: var(--font-mono);
+      white-space: nowrap;
+    }
+    .topbar-hints kbd {
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      padding: 0 3px;
+      color: var(--foreground);
+    }
+
+    /* ---------- Rail ---------- */
+    .rail {
+      width: 240px;
+      flex-shrink: 0;
+      background: var(--card);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .rail-header {
+      padding: 10px 12px 6px;
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      flex-shrink: 0;
+    }
+    .rail-header .count {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--muted-foreground);
+    }
+    .rail-title {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted-foreground);
+      font-weight: 600;
+    }
+
+    .rail-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .drop-zone {
+      margin: 6px;
+      border: 1px dashed var(--border);
+      border-radius: 8px;
+      padding: 18px 10px;
+      text-align: center;
+      color: var(--muted-foreground);
+      font-size: 11.5px;
+      flex-shrink: 0;
+      transition:
+        border-color 0.15s ease,
+        color 0.15s ease,
+        background-color 0.15s ease;
+    }
+    .drop-zone.active {
+      border-color: var(--primary);
+      color: var(--primary);
+      background: var(--primary-soft);
+    }
+    .drop-zone kbd {
+      font-family: var(--font-mono);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      padding: 0 3px;
+      color: var(--foreground);
+    }
+
+    /* ---------- Preview pane ---------- */
+    .preview-pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    .preview-canvas-area {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      overflow: auto;
+      background-image:
+        linear-gradient(45deg, var(--muted) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--muted) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--muted) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--muted) 75%);
+      background-size: 16px 16px;
+      background-position:
+        0 0,
+        0 8px,
+        8px -8px,
+        -8px 0px;
+      background-color: var(--background);
+    }
+
+    .preview-canvas-area img {
+      max-width: 100%;
+      max-height: 100%;
+      border-radius: 4px;
+    }
+
+    .empty-state {
+      color: var(--muted-foreground);
+      text-align: center;
+      font-size: 13px;
+      max-width: 260px;
+    }
+    .empty-state .big {
+      font-family: var(--font-mono);
+      font-size: 26px;
+      color: var(--foreground);
+      margin-bottom: 10px;
+    }
+
+    .statusbar {
+      flex-shrink: 0;
+      height: 34px;
+      border-top: 1px solid var(--border);
+      background: var(--card);
+      display: flex;
+      align-items: center;
+      padding: 0 14px;
+      gap: 16px;
+      font-family: var(--font-mono);
+      font-size: 11.5px;
+      color: var(--muted-foreground);
+    }
+    .statusbar b {
+      color: var(--foreground);
+      font-weight: 600;
+    }
+    .statusbar .stat-sep {
+      width: 1px;
+      height: 12px;
+      background: var(--border);
+    }
+
+    .copy-btn {
+      margin-left: auto;
+      appearance: none;
+      border: none;
+      background: var(--foreground);
+      color: var(--background);
+      font-size: 12px;
+      font-weight: 700;
+      padding: 6px 14px;
+      border-radius: 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      box-shadow: var(--shadow);
+      transition:
+        transform 0.15s ease,
+        opacity 0.15s ease;
+    }
+    .copy-btn:hover {
+      opacity: 0.9;
+      transform: scale(1.03);
+    }
+    .copy-btn:disabled {
+      opacity: 0.4;
+      cursor: default;
+      transform: none;
+      box-shadow: none;
+    }
+    .copy-btn kbd {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      border: 1px solid currentColor;
+      border-radius: 2px;
+      padding: 0 3px;
+      opacity: 0.85;
+    }
+
+    .flash-msg {
+      font-size: 11.5px;
+      font-family: var(--font-mono);
+    }
+    .flash-msg.ok {
+      color: var(--primary);
+    }
+    .flash-msg.err {
+      color: var(--muted-foreground);
+    }
+  </style>
+
+  <!--
+    The rail thumbnails (.thumb and everything inside) are built at runtime
+    via document.createElement in src/lib/tools/tatami.ts, so they never
+    carry Astro's scoped-style data-astro-cid attribute. A scoped <style>
+    block's selectors require that attribute on every element they match,
+    so these rules must stay in an is:global block or they silently never
+    apply to the dynamically created nodes.
+  -->
+  <style is:global>
+    .thumb {
+      position: relative;
+      flex-shrink: 0;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--muted);
+      overflow: hidden;
+      cursor: grab;
+      display: flex;
+      flex-direction: column;
+      transition: border-color 0.15s ease;
+    }
+    .thumb:active {
+      cursor: grabbing;
+    }
+    .thumb.dragging {
+      opacity: 0.4;
+    }
+    .thumb.drop-target {
+      border-color: var(--primary);
+    }
+    .thumb-image {
+      position: relative;
+      flex-shrink: 0;
+    }
+    .thumb img {
+      display: block;
+      width: 100%;
+      height: 96px;
+      object-fit: contain;
+      background: var(--surface-3);
+    }
+    .thumb .meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      min-width: 0;
+      padding: 6px 8px;
+    }
+    .thumb .idx {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      color: var(--muted-foreground);
+      flex-shrink: 0;
+    }
+    .thumb .dims {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      color: var(--muted-foreground);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .thumb .remove {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      background: rgb(0 0 0 / 55%);
+      color: #fff;
+      cursor: pointer;
+      font-size: 13px;
+      line-height: 1;
+      padding: 0;
+    }
+    .thumb .remove:hover {
+      background: rgb(0 0 0 / 75%);
+    }
+  </style>
+</ToolLayout>


### PR DESCRIPTION
## Summary
- Adds the Tatami tool: arrange and stitch screenshots into a single image (row, column, or grid layout) entirely in the browser.
- Row/column modes normalize images to the shortest height / narrowest width respectively, scaling down only, and tile them edge-to-edge.
- Grid mode sizes cells from the smallest image in the set and contain-fits each image into its cell (scaled down only, never upscaled), padding to preserve aspect ratio instead of cropping.

## Test plan
- [x] Drop/paste images of varying sizes and confirm row, column, and grid modes render as expected
- [x] Confirm grid mode shows no cropping and no upscaling/blur on smaller images
- [x] Confirm copy-to-clipboard works on the composited result